### PR TITLE
Fixed Overridden archives not backing up correctly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,54 +1,54 @@
 [submodule "Libs/Collections"]
 	path = Libs/Collections
-	url = ../../sanmadjack/Collections.CSharp.git
+	url = https://github.com/sanmadjack/Collections.CSharp.git
 [submodule "Libs/Config"]
 	path = Libs/Config
-	url = ../../sanmadjack/Config.CSharp.git
+	url = https://github.com/sanmadjack/Config.CSharp.git
 [submodule "Libs/Email"]
 	path = Libs/Email
-	url = ../../sanmadjack/Email.CSharp
+	url = https://github.com/sanmadjack/Email.CSharp
 [submodule "Libs/Exceptions"]
 	path = Libs/Exceptions
-	url = ../../sanmadjack/Exceptions.CSharp.git
+	url = https://github.com/sanmadjack/Exceptions.CSharp.git
 [submodule "Libs/Logger"]
 	path = Libs/Logger
-	url = ../../sanmadjack/Logger.CSharp.git
+	url = https://github.com/sanmadjack/Logger.CSharp.git
 [submodule "Libs/MVC"]
 	path = Libs/MVC
-	url = ../../sanmadjack/MVC.CSharp.git
+	url = https://github.com/sanmadjack/MVC.CSharp.git
 [submodule "Libs/Translator"]
 	path = Libs/Translator
-	url = ../../sanmadjack/Translator.CSharp.git
+	url = https://github.com/sanmadjack/Translator.CSharp.git
 [submodule "Libs/Email.WPF"]
 	path = Libs/Email.WPF
-	url = ../../sanmadjack/Email.WPF.CSharp.git
+	url = https://github.com/sanmadjack/Email.WPF.CSharp.git
 [submodule "Libs/Translator.WPF"]
 	path = Libs/Translator.WPF
-	url = ../../sanmadjack/Translator.WPF.CSharp.git
+	url = https://github.com/sanmadjack/Translator.WPF.CSharp.git
 [submodule "Libs/MVC.Translator"]
 	path = Libs/MVC.Translator
-	url = ../../sanmadjack/MVC.Translator.CSharp.git
+	url = https://github.com/sanmadjack/MVC.Translator.CSharp.git
 [submodule "Libs/MVC.WPF"]
 	path = Libs/MVC.WPF
-	url = ../../sanmadjack/MVC.WPF.CSharp.git
+	url = https://github.com/sanmadjack/MVC.WPF.CSharp.git
 [submodule "Libs/WPF"]
 	path = Libs/WPF
-	url = ../../sanmadjack/WPF.CSharp.git
+	url = https://github.com/sanmadjack/WPF.CSharp.git
 [submodule "Libs/GameSave.Info"]
 	path = Libs/GameSave.Info
-	url = ../../GameSaveInfo/Lib.CSharp.git
+	url = https://github.com/GameSaveInfo/Lib.CSharp.git
 [submodule "Libs/XmlData"]
 	path = Libs/XmlData
-	url = ../../sanmadjack/XmlData.CSharp.git
+	url = https://github.com/sanmadjack/XmlData.CSharp.git
 [submodule "MASGAU.Common/Data"]
 	path = MASGAU.Common/Data
-	url = ../../GameSaveInfo/Data.git
+	url = https://github.com/GameSaveInfo/Data.git
 [submodule "MASGAU.Common/Strings"]
 	path = MASGAU.Common/Strings
-	url = ../Strings.git
+	url = https://github.com/MASGAU/Strings.git
 [submodule "Libs/Updater"]
 	path = Libs/Updater
-	url = ../../sanmadjack/Updater.CSharp.git
+	url = https://github.com/sanmadjack/Updater.CSharp.git
 [submodule "Libs/VDF"]
 	path = Libs/VDF
-	url = ../../sanmadjack/VDF.git
+	url = https://github.com/sanmadjack/VDF.git

--- a/Installer/masgau.iss
+++ b/Installer/masgau.iss
@@ -1,5 +1,5 @@
 #define MyAppName "MASGAU"
-#define MyAppVersion "1.0.7"
+#define MyAppVersion "1.0.8"
 #define MyAppPublisher "Matthew Barbour"
 #define MyAppURL "http://masgau.org/"
 #define Mode "Debug"

--- a/MASGAU.Common/Backup/BackupProgramHandler.cs
+++ b/MASGAU.Common/Backup/BackupProgramHandler.cs
@@ -109,9 +109,11 @@ namespace MASGAU.Backup {
                                 archive_id = new ArchiveID(game.id, file);
 
                                 if (!String.IsNullOrEmpty(archive_name_override)) {
-                                    if (override_archive == null)
+                                    if (override_archive == null) {
                                         file.Type = null;
-                                    override_archive = new Archive(new FileInfo(archive_name_override), new ArchiveID(game.id, file));
+                                        override_archive = new Archive(new FileInfo(archive_name_override),
+										    new ArchiveID(game.id, file));
+									}
                                     archive = override_archive;
                                 } else {
                                     if (Archives.Get(archive_id) == null) {

--- a/MASGAU.Common/Core.cs
+++ b/MASGAU.Common/Core.cs
@@ -31,14 +31,14 @@ namespace MASGAU {
         public const string Extension = ".gb7";
         public const string seperator = "«";
         public const string owner_seperator = "@";
-        public const string version = "1.0.7";
+        public const string version = "1.0.8";
         public const string masgau_url = "http://masgau.org/";
         public const string gamesaveinfo_url = "http://gamesave.info/";
         public const string submission_email = "submissions@gamesave.info";
 
         public const bool Stable = true;
 
-        public static Version ProgramVersion = new Version(1, 0, 7);
+        public static Version ProgramVersion = new Version(1, 0, 8);
 
 
         // This stores the names of the various programs in masgau


### PR DESCRIPTION
- Fixed the Issue with overridden archives just backing up the first file (Issue #97
- Updated .gitmodules to use a https url instead of a unresolvable relative path.
- Updated version info which had been changed to 1.0.7 in a previous commit.
- Updated the VDF submodule to the commit fixing issue #107 .
